### PR TITLE
Fix TypeError: StringIO is not a subclass of IO

### DIFF
--- a/lib/gooddata/rest/connection.rb
+++ b/lib/gooddata/rest/connection.rb
@@ -188,7 +188,7 @@ module GoodData
             :url => url
           }.merge(cookies)
 
-          if where.is_a?(IO)
+          if where.is_a?(IO) || where.is_a?(StringIO)
             RestClient::Request.execute(raw) do |chunk, _x, response|
               if response.code.to_s != '200'
                 fail ArgumentError, "Error downloading #{url}. Got response: #{response.code} #{response} #{response.body}"


### PR DESCRIPTION
This will fix an annoying TypeError in the GD gem that shortcircuits more valuable error messages.

@urnf 
